### PR TITLE
mb skills should not use table view

### DIFF
--- a/src/commands/skills/list.ts
+++ b/src/commands/skills/list.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { loadVisibleSkills } from "../../core/skills";
 import type { ResourceView } from "../../domain/view";
 import { renderList } from "../../output/render";
+import { renderSkillList } from "../../output/skill-list";
 import { listEnvelopeSchema, wrapList } from "../../output/types";
 import { outputFlags } from "../flags";
 import { defineMetabaseCommand } from "../runtime";
@@ -37,6 +38,10 @@ export default defineMetabaseCommand({
       name: s.name,
       description: s.description,
     }));
-    renderList(wrapList(items), skillSummaryView, ctx);
+    if (ctx.format === "json" || ctx.fields !== undefined || ctx.full) {
+      renderList(wrapList(items), skillSummaryView, ctx);
+      return;
+    }
+    renderSkillList(items, ctx.maxBytes);
   },
 });

--- a/src/output/skill-list.test.ts
+++ b/src/output/skill-list.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderSkillList, type SkillListRow } from "./skill-list";
+
+interface Streams {
+  stdout: string;
+  stderr: string;
+}
+
+let streams: Streams;
+let originalColumns: number | undefined;
+
+beforeEach(() => {
+  streams = { stdout: "", stderr: "" };
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    streams.stdout += String(chunk);
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    streams.stderr += String(chunk);
+    return true;
+  });
+  originalColumns = process.stdout.columns;
+  Object.defineProperty(process.stdout, "columns", { value: 40, configurable: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process.stdout, "columns", {
+    value: originalColumns,
+    configurable: true,
+  });
+});
+
+const rows: SkillListRow[] = [
+  { name: "core", description: "Drive a Metabase instance from the terminal." },
+  { name: "mbql", description: "Author Metabase Query Language." },
+];
+
+describe("renderSkillList", () => {
+  it("prints each skill name on its own line with the description wrapped and indented below", () => {
+    renderSkillList(rows, 0);
+    expect(streams.stdout).toBe(
+      "core\n" +
+        "  Drive a Metabase instance from the\n" +
+        "  terminal.\n\n" +
+        "mbql\n" +
+        "  Author Metabase Query Language.\n\n",
+    );
+    expect(streams.stderr).toBe("");
+  });
+
+  it("emits a no-results marker for an empty list", () => {
+    renderSkillList([], 0);
+    expect(streams.stdout).toBe("(no results)\n");
+  });
+
+  it("drops trailing skills past the byte cap and warns with the full byte count", () => {
+    const full =
+      "core\n  Drive a Metabase instance from the\n  terminal.\n\nmbql\n  Author Metabase Query Language.\n\n";
+    const firstBlockBytes = Buffer.byteLength(
+      "core\n  Drive a Metabase instance from the\n  terminal.\n\n",
+      "utf8",
+    );
+
+    renderSkillList(rows, firstBlockBytes);
+
+    expect(streams.stdout).toBe("core\n  Drive a Metabase instance from the\n  terminal.\n\n");
+    expect(streams.stderr).toBe(
+      `… cut at ${Buffer.byteLength(full, "utf8")} bytes; rerun with --max-bytes 0\n`,
+    );
+  });
+});

--- a/src/output/skill-list.ts
+++ b/src/output/skill-list.ts
@@ -1,0 +1,70 @@
+import { listTruncationNotice, warn } from "./notice";
+
+export interface SkillListRow {
+  name: string;
+  description: string;
+}
+
+const DEFAULT_TERMINAL_WIDTH = 80;
+const MIN_WRAP_WIDTH = 24;
+const DESCRIPTION_INDENT = "  ";
+
+export function renderSkillList(rows: readonly SkillListRow[], maxBytes: number): void {
+  if (rows.length === 0) {
+    process.stdout.write("(no results)\n");
+    return;
+  }
+  const width = wrapWidth();
+  const blocks = rows.map((row) => renderSkillBlock(row, width));
+  const fullText = blocks.join("");
+  const fullBytes = Buffer.byteLength(fullText, "utf8");
+  if (maxBytes <= 0 || fullBytes <= maxBytes) {
+    process.stdout.write(fullText);
+    return;
+  }
+
+  let used = 0;
+  let kept = "";
+  for (const block of blocks) {
+    const next = used + Buffer.byteLength(block, "utf8");
+    if (next > maxBytes) {
+      break;
+    }
+    used = next;
+    kept += block;
+  }
+  process.stdout.write(kept);
+  warn(listTruncationNotice(fullBytes));
+}
+
+function renderSkillBlock(row: SkillListRow, width: number): string {
+  const lines = wrapText(row.description, width - DESCRIPTION_INDENT.length);
+  const body = lines.map((line) => DESCRIPTION_INDENT + line).join("\n");
+  return body === "" ? `${row.name}\n\n` : `${row.name}\n${body}\n\n`;
+}
+
+function wrapText(text: string, width: number): string[] {
+  const limit = Math.max(width, MIN_WRAP_WIDTH);
+  const words = text.split(/\s+/).filter((word) => word.length > 0);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current === "") {
+      current = word;
+    } else if (current.length + 1 + word.length <= limit) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current !== "") {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function wrapWidth(): number {
+  const columns = process.stdout.columns;
+  return typeof columns === "number" && columns > 0 ? columns : DEFAULT_TERMINAL_WIDTH;
+}


### PR DESCRIPTION
### Description

Although skills are for agents and they use json format still the default table view for `mb skills` is unreadable and should be replaced with a list view

Before
<img width="1297" height="624" alt="Screenshot 2026-06-30 at 3 21 54 PM" src="https://github.com/user-attachments/assets/aab7cd26-0fca-4ea1-ab25-9c1342e616e2" />

After
<img width="1298" height="420" alt="Screenshot 2026-06-30 at 3 24 51 PM" src="https://github.com/user-attachments/assets/138825f6-f620-4fdb-92ed-3af1a5ce45e6" />
